### PR TITLE
Fix field offset calculation

### DIFF
--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -1,6 +1,7 @@
 use zst_volatile::VolatileStruct;
 
 #[derive(VolatileStruct)]
+#[repr(C)]
 pub struct Child1 {
     field1: u32,
     field2: u32,
@@ -9,6 +10,7 @@ pub struct Child1 {
 }
 
 #[derive(VolatileStruct)]
+#[repr(C)]
 pub struct Child2 {
     field1: u32,
     field2: u32,
@@ -16,6 +18,7 @@ pub struct Child2 {
 }
 
 #[derive(VolatileStruct)]
+#[repr(C)]
 pub struct Parent {
     child1: Child1,
     child2: Child2,

--- a/zst-volatile-macro/Cargo.toml
+++ b/zst-volatile-macro/Cargo.toml
@@ -9,3 +9,4 @@ proc-macro = true
 [dependencies]
 quote = "1.0.23"
 syn = { version = "1.0.107", features = ["full"] }
+proc-macro2 = "1.0"

--- a/zst-volatile-macro/src/lib.rs
+++ b/zst-volatile-macro/src/lib.rs
@@ -67,7 +67,7 @@ fn parse_repr(attrs: &[Attribute]) -> Result<bool, &'static str> {
         _ => return Err("#[repr(...)] invalid format"),
     };
 
-    // Make sure #[repr(C)] exits
+    // Make sure #[repr(C)] exists
     repr_metas
         .nested
         .iter()

--- a/zst-volatile-macro/src/lib.rs
+++ b/zst-volatile-macro/src/lib.rs
@@ -1,18 +1,22 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Attribute, Data, DeriveInput, Error};
+use syn::{
+    parse_macro_input, punctuated::Punctuated, Attribute, Data, DeriveInput, Error, Lit, Meta,
+    NestedMeta, Token,
+};
 
 #[proc_macro_derive(VolatileStruct)]
 pub fn derive_volatile(tts: TokenStream) -> TokenStream {
-    // FIXME: Check for repr(C), currently we just assume this.
-
     let input = parse_macro_input!(tts as DeriveInput);
-
-    let packed = parse_repr(&input.attrs).unwrap();
 
     let Data::Struct(strukt) = &input.data else {
         return Error::new_spanned(&input,"only structs are supported").into_compile_error().into();
     };
+
+    let (repr_c, repr_align, repr_packed) = parse_repr(&input.attrs).unwrap();
+    if !repr_c {
+        panic!("VolatileStruct needs #[repr(C)]")
+    }
 
     let vis = &input.vis;
     let ident = &input.ident;
@@ -25,12 +29,13 @@ pub fn derive_volatile(tts: TokenStream) -> TokenStream {
         let ident = &field.ident.as_ref().unwrap();
         let ty = &field.ty;
 
-        if !packed {
-            // Align the field.
-            offset = quote! {
-                ::zst_volatile::offset::Align::<#offset, #ty>
-            };
-        }
+        // FIXME: How to process #[repr(align(N))] and #[repr(packed(N))]?
+        // if let Some(pack_n) = repr_packed {
+        //     // Align the field.
+        //     offset = quote! {
+        //         ::zst_volatile::offset::Align::<#offset, #ty>
+        //     };
+        // }
 
         let field = quote! {
             #vis #ident: ::zst_volatile::Volatile<#ty, #offset>
@@ -56,34 +61,41 @@ pub fn derive_volatile(tts: TokenStream) -> TokenStream {
     .into()
 }
 
-fn parse_repr(attrs: &[Attribute]) -> Result<bool, &'static str> {
-    let repr = attrs
-        .iter()
-        .find(|a| a.path.is_ident("repr"))
-        .ok_or("VolatileStruct can only apply to #[repr(C, ...)]")?;
+fn parse_repr(attrs: &[Attribute]) -> syn::Result<(bool, Option<usize>, Option<usize>)> {
+    let mut repr_c = false;
+    let mut repr_align = None::<usize>;
+    let mut repr_packed = None::<usize>;
+    for a in attrs {
+        if a.path.is_ident("repr") {
+            for meta in a.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)? {
+                match meta {
+                    Meta::Path(path) if path.is_ident("C") => repr_c = true,
+                    Meta::Path(path) if path.is_ident("packed") => repr_packed = Some(1),
+                    Meta::List(metas) if meta.path().is_ident("packed") => {
+                        let nested: Vec<_> = metas.nested.iter().collect();
+                        match nested.as_slice() {
+                            &[NestedMeta::Lit(Lit::Int(i))] => {
+                                let n: usize = i.base10_parse()?;
+                                repr_packed = Some(n)
+                            }
+                            _ => {} // Wrong packed format
+                        }
+                    }
+                    Meta::List(metas) if meta.path().is_ident("align") => {
+                        let nested: Vec<_> = metas.nested.iter().collect();
+                        match nested.as_slice() {
+                            &[NestedMeta::Lit(Lit::Int(i))] => {
+                                let n: usize = i.base10_parse()?;
+                                repr_align = Some(n)
+                            }
+                            _ => {} // Wrong align format
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
 
-    let repr_metas = match repr.parse_meta().unwrap() {
-        syn::Meta::List(l) => l,
-        _ => return Err("#[repr(...)] invalid format"),
-    };
-
-    // Make sure #[repr(C)] exists
-    repr_metas
-        .nested
-        .iter()
-        .find(|m| match m {
-            syn::NestedMeta::Meta(syn::Meta::Path(p)) => p.is_ident("C"),
-            _ => false,
-        })
-        .ok_or("VolatileStruct can only apply to #[repr(C, ...)]")?;
-
-    // Check if packed struct
-    Ok(repr_metas
-        .nested
-        .iter()
-        .find(|m| match m {
-            syn::NestedMeta::Meta(syn::Meta::Path(p)) => p.is_ident("packed"),
-            _ => false,
-        })
-        .is_some())
+    Ok((repr_c, repr_align, repr_packed))
 }

--- a/zst-volatile-macro/src/lib.rs
+++ b/zst-volatile-macro/src/lib.rs
@@ -1,4 +1,5 @@
 use proc_macro::TokenStream;
+use proc_macro2::Literal;
 use quote::{format_ident, quote};
 use syn::{
     parse_macro_input, punctuated::Punctuated, Attribute, Data, DeriveInput, Error, Lit, Meta,
@@ -13,57 +14,73 @@ pub fn derive_volatile(tts: TokenStream) -> TokenStream {
         return Error::new_spanned(&input,"only structs are supported").into_compile_error().into();
     };
 
-    let (repr_c, repr_align, repr_packed) = parse_repr(&input.attrs).unwrap();
+    let (repr_c, repr_packed) = parse_repr(&input.attrs).unwrap();
     if !repr_c {
-        panic!("VolatileStruct needs #[repr(C)]")
+        return Error::new_spanned(&input, "VolatileStruct needs #[repr(C)]")
+            .into_compile_error()
+            .into();
     }
 
-    let vis = &input.vis;
-    let ident = &input.ident;
-    let volatile_ident = format_ident!("Volatile{}", ident);
+    let s_vis = &input.vis;
+    let s_ident = &input.ident;
+    let volatile_ident = format_ident!("Volatile{}", s_ident);
 
     let mut offset = quote! { ::zst_volatile::offset::Zero };
-    let fields = strukt.fields.iter().map(|field| {
-        let vis = &field.vis;
+    let mut field_wrappers = Vec::new();
+    let mut fields = Vec::new();
+
+    for f in &strukt.fields {
+        let f_vis = &f.vis;
         // FIXME: Make this compatible with unnamed structs.
-        let ident = &field.ident.as_ref().unwrap();
-        let ty = &field.ty;
+        let f_ident = &f.ident.as_ref().unwrap();
+        let f_ty = &f.ty;
 
-        // FIXME: How to process #[repr(align(N))] and #[repr(packed(N))]?
-        // if let Some(pack_n) = repr_packed {
-        //     // Align the field.
-        //     offset = quote! {
-        //         ::zst_volatile::offset::Align::<#offset, #ty>
-        //     };
-        // }
+        if let Some(n) = repr_packed {
+            // Generate a unique non-aligned wrapper type for each field
+            let f_wrapper = format_ident!("{}_{}", s_ident, f_ident);
+            let lit_n = Literal::usize_unsuffixed(n);
 
-        let field = quote! {
-            #vis #ident: ::zst_volatile::Volatile<#ty, #offset>
-        };
+            field_wrappers.push(quote! {
+                #[allow(non_camel_case_types)]
+                #[repr(C, packed(#lit_n))]
+                #f_vis struct #f_wrapper(#f_ty);
+            });
 
-        // Calculate the minimum offset for the next field.
+            offset = quote! {
+                ::zst_volatile::offset::Align::<#offset, #f_wrapper>
+            };
+        } else {
+            offset = quote! {
+                ::zst_volatile::offset::Align::<#offset, #f_ty>
+            };
+        }
+
+        fields.push(quote! {
+            #f_vis #f_ident: ::zst_volatile::Volatile<#f_ty, #offset>
+        });
+
+        // Calculate the offset for the next field.
         offset = quote! {
-            ::zst_volatile::offset::PastField::<#offset, #ty>
+            ::zst_volatile::offset::PastField::<#offset, #f_ty>
         };
-
-        field
-    });
+    }
 
     quote! {
-        #vis struct #volatile_ident {
+        #(#field_wrappers)*
+
+        #s_vis struct #volatile_ident {
             #(#fields,)*
         }
 
-        unsafe impl ::zst_volatile::VolatileStruct for #ident {
+        unsafe impl ::zst_volatile::VolatileStruct for #s_ident {
             type Struct = #volatile_ident;
         }
     }
     .into()
 }
 
-fn parse_repr(attrs: &[Attribute]) -> syn::Result<(bool, Option<usize>, Option<usize>)> {
+fn parse_repr(attrs: &[Attribute]) -> syn::Result<(bool, Option<usize>)> {
     let mut repr_c = false;
-    let mut repr_align = None::<usize>;
     let mut repr_packed = None::<usize>;
     for a in attrs {
         if a.path.is_ident("repr") {
@@ -76,19 +93,13 @@ fn parse_repr(attrs: &[Attribute]) -> syn::Result<(bool, Option<usize>, Option<u
                         match nested.as_slice() {
                             &[NestedMeta::Lit(Lit::Int(i))] => {
                                 let n: usize = i.base10_parse()?;
-                                repr_packed = Some(n)
+                                if let Some(old) = repr_packed {
+                                    if n < old {
+                                        repr_packed = Some(n)
+                                    }
+                                }
                             }
                             _ => {} // Wrong packed format
-                        }
-                    }
-                    Meta::List(metas) if meta.path().is_ident("align") => {
-                        let nested: Vec<_> = metas.nested.iter().collect();
-                        match nested.as_slice() {
-                            &[NestedMeta::Lit(Lit::Int(i))] => {
-                                let n: usize = i.base10_parse()?;
-                                repr_align = Some(n)
-                            }
-                            _ => {} // Wrong align format
                         }
                     }
                     _ => {}
@@ -97,5 +108,5 @@ fn parse_repr(attrs: &[Attribute]) -> syn::Result<(bool, Option<usize>, Option<u
         }
     }
 
-    Ok((repr_c, repr_align, repr_packed))
+    Ok((repr_c, repr_packed))
 }

--- a/zst-volatile-macro/src/lib.rs
+++ b/zst-volatile-macro/src/lib.rs
@@ -1,12 +1,14 @@
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Data, DeriveInput, Error};
+use syn::{parse_macro_input, Attribute, Data, DeriveInput, Error};
 
 #[proc_macro_derive(VolatileStruct)]
 pub fn derive_volatile(tts: TokenStream) -> TokenStream {
     // FIXME: Check for repr(C), currently we just assume this.
 
     let input = parse_macro_input!(tts as DeriveInput);
+
+    let packed = parse_repr(&input.attrs).unwrap();
 
     let Data::Struct(strukt) = &input.data else {
         return Error::new_spanned(&input,"only structs are supported").into_compile_error().into();
@@ -23,9 +25,15 @@ pub fn derive_volatile(tts: TokenStream) -> TokenStream {
         let ident = &field.ident.as_ref().unwrap();
         let ty = &field.ty;
 
-        // Align the field.
-        let field_offset = quote! {
-            ::zst_volatile::offset::Align::<#offset, #ty>
+        if !packed {
+            // Align the field.
+            offset = quote! {
+                ::zst_volatile::offset::Align::<#offset, #ty>
+            };
+        }
+
+        let field = quote! {
+            #vis #ident: ::zst_volatile::Volatile<#ty, #offset>
         };
 
         // Calculate the minimum offset for the next field.
@@ -33,9 +41,7 @@ pub fn derive_volatile(tts: TokenStream) -> TokenStream {
             ::zst_volatile::offset::PastField::<#offset, #ty>
         };
 
-        quote! {
-            #vis #ident: ::zst_volatile::Volatile<#ty, #field_offset>
-        }
+        field
     });
 
     quote! {
@@ -48,4 +54,36 @@ pub fn derive_volatile(tts: TokenStream) -> TokenStream {
         }
     }
     .into()
+}
+
+fn parse_repr(attrs: &[Attribute]) -> Result<bool, &'static str> {
+    let repr = attrs
+        .iter()
+        .find(|a| a.path.is_ident("repr"))
+        .ok_or("VolatileStruct can only apply to #[repr(C, ...)]")?;
+
+    let repr_metas = match repr.parse_meta().unwrap() {
+        syn::Meta::List(l) => l,
+        _ => return Err("#[repr(...)] invalid format"),
+    };
+
+    // Make sure #[repr(C)] exits
+    repr_metas
+        .nested
+        .iter()
+        .find(|m| match m {
+            syn::NestedMeta::Meta(syn::Meta::Path(p)) => p.is_ident("C"),
+            _ => false,
+        })
+        .ok_or("VolatileStruct can only apply to #[repr(C, ...)]")?;
+
+    // Check if packed struct
+    Ok(repr_metas
+        .nested
+        .iter()
+        .find(|m| match m {
+            syn::NestedMeta::Meta(syn::Meta::Path(p)) => p.is_ident("packed"),
+            _ => false,
+        })
+        .is_some())
 }


### PR DESCRIPTION
Fix Freax13/zst-volatile#1

- Fix field offset calculation
- Enforce `#[repr(C)]`
- Support both packed/non-packed struct (`#[repr(packed)]`)