### PR TITLE
correctly handle repr attribute

### DIFF
--- a/src/alignment.rs
+++ b/src/alignment.rs
@@ -1,0 +1,40 @@
+/// An alignment restriction to be placed on a volatile value. In most cases
+/// this will be the normal alignment of the type. The fields of
+/// `#[repr(packed(n))]` structs will have their alignment restricted to `n`.
+///
+/// A volatile value with this restriction must only be read and written
+/// through the wrapper type.
+///
+/// Users of this crate shouldn't have to worry about this and they usually
+/// shouldn't have to implement this trait.
+///
+/// # Safety
+///
+/// `Wrapper<T>` must be a transparent wrapper around `T` except in that the
+/// wrapper is allowed to restrict the alignment with a `#[repr(packed(n))]`
+/// attribute.
+/// The `wrap` and `unwrap` values can be used to move a value into and out of
+/// the wrapper.
+pub unsafe trait Alignment {
+    type Wrapper<T>;
+
+    fn wrap<T>(value: T) -> Self::Wrapper<T>;
+    fn unwrap<T>(value: Self::Wrapper<T>) -> T;
+}
+
+/// The normal alignment of the type.
+pub struct Normal;
+
+unsafe impl Alignment for Normal {
+    type Wrapper<T> = T;
+
+    #[inline]
+    fn wrap<T>(value: T) -> Self::Wrapper<T> {
+        value
+    }
+
+    #[inline]
+    fn unwrap<T>(value: Self::Wrapper<T>) -> T {
+        value
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,16 @@ use core::{
 
 pub use zst_volatile_macro::VolatileStruct;
 
+use alignment::{Alignment, Normal};
 use offset::{Offset, Zero};
 
+pub mod alignment;
 pub mod offset;
 
-pub struct Volatile<T, O = Zero> {
+pub struct Volatile<T, O = Zero, A = Normal> {
     _type_marker: PhantomData<T>,
     _offset_marker: PhantomData<O>,
+    _alignment_marker: PhantomData<A>,
 }
 
 impl<T> Volatile<T> {
@@ -27,9 +30,10 @@ impl<T> Volatile<T> {
     }
 }
 
-impl<T, O> Volatile<T, O>
+impl<T, O, A> Volatile<T, O, A>
 where
     O: Offset,
+    A: Alignment,
 {
     pub fn as_ptr(&self) -> NonNull<T> {
         let base = self as *const Self as *const u8;
@@ -39,45 +43,59 @@ where
         NonNull::new(ptr).unwrap()
     }
 
+    fn as_wrapper_pointer(&self) -> NonNull<A::Wrapper<T>> {
+        self.as_ptr().cast()
+    }
+
     pub fn read(&self) -> T
     where
         T: Copy,
     {
-        let ptr = self.as_ptr();
-        unsafe { ptr.as_ptr().read_volatile() }
+        // Read the value through the wrapper. This ensures that the pointer is
+        // always aligned.
+        let ptr = self.as_wrapper_pointer();
+        let wrapped = unsafe { ptr.as_ptr().read_volatile() };
+        A::unwrap(wrapped)
     }
 
     pub fn write(&mut self, value: T)
     where
         T: Copy,
     {
-        let ptr = self.as_ptr();
+        // Write the value through the wrapper. This ensures that the pointer
+        // is always aligned.
+        let value = A::wrap(value);
+        let ptr = self.as_wrapper_pointer();
         unsafe { ptr.as_ptr().write_volatile(value) }
     }
 }
 
 pub unsafe trait VolatileStruct {
-    type Struct;
+    type Struct<A>
+    where
+        A: Alignment;
 }
 
-impl<T, O> Deref for Volatile<T, O>
+impl<T, O, A> Deref for Volatile<T, O, A>
 where
     T: VolatileStruct,
     O: Offset,
+    A: Alignment,
 {
-    type Target = T::Struct;
+    type Target = T::Struct<A>;
 
     fn deref(&self) -> &Self::Target {
-        unsafe { &*(self.as_ptr().as_ptr() as *const T::Struct) }
+        unsafe { &*(self.as_ptr().as_ptr() as *const T::Struct<A>) }
     }
 }
 
-impl<T, O> DerefMut for Volatile<T, O>
+impl<T, O, A> DerefMut for Volatile<T, O, A>
 where
     T: VolatileStruct,
     O: Offset,
+    A: Alignment,
 {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *(self.as_ptr().as_ptr() as *mut T::Struct) }
+        unsafe { &mut *(self.as_ptr().as_ptr() as *mut T::Struct<A>) }
     }
 }

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -1,6 +1,7 @@
 use zst_volatile::VolatileStruct;
 
 #[derive(VolatileStruct)]
+#[repr(C)]
 pub struct Child1 {
     field1: u32,
     field2: u32,
@@ -9,6 +10,7 @@ pub struct Child1 {
 }
 
 #[derive(VolatileStruct)]
+#[repr(C)]
 pub struct Child2 {
     field1: u32,
     field2: u32,
@@ -16,6 +18,7 @@ pub struct Child2 {
 }
 
 #[derive(VolatileStruct)]
+#[repr(C)]
 pub struct Parent {
     child1: Child1,
     child2: Child2,

--- a/tests/test_struct.rs
+++ b/tests/test_struct.rs
@@ -10,9 +10,9 @@ pub struct Child1 {
 }
 
 #[derive(VolatileStruct)]
-#[repr(C)]
+#[repr(C, packed)]
 pub struct Child2 {
-    field1: u32,
+    field1: u8,
     field2: u32,
     field3: u32,
 }
@@ -39,7 +39,7 @@ pub fn sum_parent(parent: &VolatileParent) -> u32 {
 }
 
 pub fn sum_child2(child: &VolatileChild2) -> u32 {
-    child.field1.read() + child.field2.read() + child.field3.read()
+    u32::from(child.field1.read()) + child.field2.read() + child.field3.read()
 }
 
 pub fn modify(parent: &mut VolatileParent) {

--- a/zst-volatile-macro/Cargo.toml
+++ b/zst-volatile-macro/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0.66"
 quote = "1.0.23"
 syn = { version = "1.0.107", features = ["full"] }

--- a/zst-volatile-macro/src/lib.rs
+++ b/zst-volatile-macro/src/lib.rs
@@ -1,16 +1,27 @@
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, Data, DeriveInput, Error};
+use syn::{parse_macro_input, Attribute, Data, DeriveInput, Error, Lit, Meta, NestedMeta, Result};
 
 #[proc_macro_derive(VolatileStruct)]
 pub fn derive_volatile(tts: TokenStream) -> TokenStream {
-    // FIXME: Check for repr(C), currently we just assume this.
-
     let input = parse_macro_input!(tts as DeriveInput);
 
     let Data::Struct(strukt) = &input.data else {
-        return Error::new_spanned(&input,"only structs are supported").into_compile_error().into();
+        return Error::new_spanned(&input, "only structs are supported")
+            .into_compile_error()
+            .into();
     };
+
+    let packed = match check_repr(&input.attrs) {
+        Ok(packed) => packed,
+        Err(err) => return err.into_compile_error().into(),
+    };
+    if packed.is_some() {
+        return Error::new(Span::call_site(), "packed structs are not supported")
+            .into_compile_error()
+            .into();
+    }
 
     let vis = &input.vis;
     let ident = &input.ident;
@@ -48,4 +59,55 @@ pub fn derive_volatile(tts: TokenStream) -> TokenStream {
         }
     }
     .into()
+}
+
+fn check_repr(attrs: &[Attribute]) -> Result<Option<usize>> {
+    let mut is_c_repr = false;
+    let mut packed = None;
+
+    for attr in attrs.iter().filter(|a| a.path.is_ident("repr")) {
+        let meta = attr.parse_meta()?;
+        let Meta::List(list) = meta else {
+            return Err(Error::new_spanned(meta, "expected list"));
+        };
+        for nested_meta in list.nested {
+            let NestedMeta::Meta(m) = nested_meta else {
+                return Err(Error::new_spanned(nested_meta, "expected meta"));
+            };
+            if m.path().is_ident("C") {
+                is_c_repr = true;
+            } else if m.path().is_ident("packed") {
+                match m {
+                    Meta::Path(_) => packed = Some(1),
+                    Meta::List(list) => {
+                        if list.nested.len() != 1 {
+                            return Err(Error::new_spanned(list, "expected exactly one value"));
+                        }
+                        let first = list.nested.first().unwrap();
+                        let NestedMeta::Lit(lit) = first else {
+                            return Err(Error::new_spanned(list, "expected literal"));
+                        };
+                        let Lit::Int(lit_int) = lit else {
+                            return Err(Error::new_spanned(list, "expected integer literal"));
+                        };
+                        let value = lit_int.base10_parse()?;
+                        packed = Some(value);
+                    }
+                    Meta::NameValue(_) => {
+                        return Err(Error::new_spanned(m, "expected path or list meta"));
+                    }
+                }
+            } else if m.path().is_ident("align") {
+                // Ignore
+            } else {
+                return Err(Error::new_spanned(m, "unexpected attribute"));
+            }
+        }
+    }
+
+    if !is_c_repr {
+        return Err(Error::new(Span::call_site(), "struct has to be #[repr(C)]"));
+    }
+
+    Ok(packed)
 }


### PR DESCRIPTION
This pr fixes offsets, adds a check to ensure that structs are `#[repr(C)]` and correctly handles `#[repr(packed(n))]`.

Unaligned values are read and written in such a way that the minimum alignment is preserved. This could be useful for some types like `u16` because those will still be correctly aligned in a `#[repr(packed(2))]` struct and so reads and writes to such values will not get pessimised by the compiler. 

This pr is based on some of the ideas by @fubupc in #2, so credits to them. Apologies to @fubupc for taking this over. I wasn't sure if #2 was going in the right direction, experimented a bit and ended up with this. I recognize and am thankful for the time you invested in your pr. Please let me know what you think of this pr.

Closes #1
Supersedes #2